### PR TITLE
Feature/testing focus

### DIFF
--- a/src/auto-complete.ts
+++ b/src/auto-complete.ts
@@ -1,0 +1,40 @@
+import { Config } from './providers/config';
+import { TomTomAPIConfig, getPlaceAutocomplete } from './third-party/maps-api';
+import {
+  AddressSearch,
+  addressSearch,
+  AddressSuggestions,
+  PartialAddress
+} from './lib/address-search';
+import { AutoCompleteError } from './lib/errors';
+
+export type AutoCompleteVersion = 1 | 2;
+
+export type AutoCompleteConfig = {
+  version: AutoCompleteVersion;
+};
+
+export type AddressAutoComplete = {
+  search: (address: PartialAddress) => Promise<AddressSuggestions>;
+  version: () => AutoCompleteVersion;
+};
+
+// function to inject the tom tom search API into the autoComplete library code
+function configure(version: AutoCompleteVersion): AddressSearch {
+  if (version === 1 || version === 2) {
+    const tomTomConfig: TomTomAPIConfig = {
+      key: Config.tomTomApiKey,
+      version: 2,
+      countrySet: Config.tomTomCountriesAllowed
+    };
+
+    const mapsApi = getPlaceAutocomplete(tomTomConfig);
+    return addressSearch(mapsApi);
+  } else {
+    throw Error(AutoCompleteError.UNSUPPORTED_LIBRARY_VERSION);
+  }
+}
+
+export function AutoComplete(config: AutoCompleteConfig): AddressAutoComplete {
+  return { search: configure(config.version), version: () => config.version };
+}

--- a/src/auto-complete.ts
+++ b/src/auto-complete.ts
@@ -1,5 +1,5 @@
 import { Config } from './providers/config';
-import { TomTomAPIConfig, getPlaceAutocomplete } from './third-party/maps-api';
+import { TomTomAPIConfig, getPlaceAutocomplete, mapsApi } from './third-party/maps-api';
 import {
   AddressSearch,
   addressSearch,
@@ -28,8 +28,8 @@ function configure(version: AutoCompleteVersion): AddressSearch {
       countrySet: Config.tomTomCountriesAllowed
     };
 
-    const mapsApi = getPlaceAutocomplete(tomTomConfig);
-    return addressSearch(mapsApi);
+    const tomTomApi = getPlaceAutocomplete(tomTomConfig, mapsApi);
+    return addressSearch(tomTomApi);
   } else {
     throw Error(AutoCompleteError.UNSUPPORTED_LIBRARY_VERSION);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,12 @@
-import {
-  AddressAutoComplete,
-  AddressSuggestion,
-  AddressSuggestions,
-  autoComplete,
-  PartialAddress
-} from './lib/auto-complete';
-import { Config } from './providers/config';
-import { getPlaceAutocomplete, TomTomAPIConfig } from './third-party/maps-api';
-
-// function to inject the tom tom search API into the autoComplete library code
-function configure(): AddressAutoComplete {
-  const tomTomConfig: TomTomAPIConfig = {
-    key: Config.tomTomApiKey,
-    version: 2,
-    countrySet: Config.tomTomCountriesAllowed
-  };
-
-  const mapsApi = getPlaceAutocomplete(tomTomConfig);
-  return autoComplete(mapsApi);
-}
-
-const getAutoCompleteDetails = configure(); // wire up the dependencies
+import { AddressAutoComplete, AutoComplete, AutoCompleteConfig } from './auto-complete';
+import { AddressSuggestion, AddressSuggestions, PartialAddress } from './lib/address-search';
+import { AutoCompleteError } from './lib/errors';
 
 // re-export types that we want to be available to the library users
 export {
-  getAutoCompleteDetails,
+  AutoComplete,
+  AutoCompleteConfig,
+  AutoCompleteError,
   AddressAutoComplete,
   AddressSuggestion,
   AddressSuggestions,

--- a/src/lib/address-search.ts
+++ b/src/lib/address-search.ts
@@ -13,13 +13,13 @@ export type AddressSuggestion = {
   components: AddressComponents;
 };
 export type AddressSuggestions = Array<AddressSuggestion>;
-export type AddressAutoComplete = (address: PartialAddress) => Promise<AddressSuggestions>;
+export type AddressSearch = (address: PartialAddress) => Promise<AddressSuggestion[]>;
 
-// Type alias to allow a separation to what the library consumer see and the depndency
+// Type to allow a separation to what the library consumer see and the depndency
 // the third party API will see
 export type SearchAPI = (address: PartialAddress) => Promise<AddressComponents[]>;
 
-function configureAutoComplete(searchApi: SearchAPI): AddressAutoComplete {
+function configureAddressSearch(searchApi: SearchAPI): AddressSearch {
   return async (address: PartialAddress): Promise<AddressSuggestions> => {
     const searchResults = await searchApi(address).then((components) => components);
     return searchResults.map((components) => {
@@ -28,4 +28,4 @@ function configureAutoComplete(searchApi: SearchAPI): AddressAutoComplete {
   };
 }
 
-export const autoComplete = (searchApi: SearchAPI) => configureAutoComplete(searchApi);
+export const addressSearch = (searchApi: SearchAPI) => configureAddressSearch(searchApi);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,3 @@
+export enum AutoCompleteError {
+  UNSUPPORTED_LIBRARY_VERSION = 'Unsupported Library Version Provided'
+}

--- a/src/third-party/maps-api.ts
+++ b/src/third-party/maps-api.ts
@@ -34,7 +34,7 @@ export type TomTomAPIResponse = AxiosResponse<{
 
 // ensure the returned API result conforms to the expected contract required
 // by the library internally to produce a meaningful suggestion
-export function validResult(result: TomTomAPIResult): boolean {
+function validResult(result: TomTomAPIResult): boolean {
   return (
     result.hasOwnProperty('id') &&
     result.hasOwnProperty('address') &&
@@ -43,7 +43,10 @@ export function validResult(result: TomTomAPIResult): boolean {
 }
 
 // https://developer.tomtom.com/search-api/documentation/search-service/fuzzy-search
-async function mapsApi(config: TomTomAPIConfig, address: PartialAddress) {
+export async function mapsApi(
+  config: TomTomAPIConfig,
+  address: PartialAddress
+): Promise<TomTomAPIResponse> {
   const response: TomTomAPIResponse = await axios.get(
     `https://api.tomtom.com/search/${config.version}/search/${address}.json`,
     {
@@ -58,12 +61,14 @@ async function mapsApi(config: TomTomAPIConfig, address: PartialAddress) {
   return response;
 }
 
+export type TomTomMapsAPI = typeof mapsApi;
+
 // This function is doing the mapping from the third party API into our internal library
 // data structure to ensure our internal library code does not create a dependency
 // to the external third party library
-export function getPlaceAutocomplete(config: TomTomAPIConfig): SearchAPI {
+export function getPlaceAutocomplete(config: TomTomAPIConfig, api: TomTomMapsAPI): SearchAPI {
   return async (address: PartialAddress) => {
-    const autocomplete = await mapsApi(config, address);
+    const autocomplete = await api(config, address);
     return autocomplete.data.results.filter(validResult).map((result): AddressComponents => {
       return {
         placeId: result.id,

--- a/src/third-party/maps-api.ts
+++ b/src/third-party/maps-api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from 'axios';
-import { AddressComponents, PartialAddress, SearchAPI } from '../lib/auto-complete';
+import { AddressComponents, PartialAddress, SearchAPI } from '../lib/address-search';
 import { valueOrDefault } from '../helpers';
 
 const SEARCH_LIMIT = 100;

--- a/test/address-search.test.ts
+++ b/test/address-search.test.ts
@@ -33,5 +33,6 @@ describe('Test the address search component', () => {
     expect(firstComponents).toHaveProperty('country');
     expect(firstComponents).toHaveProperty('freeformAddress');
     expect(firstComponents).toHaveProperty('municipality');
+    expect(firstComponents).toMatchObject(addressComponents);
   });
 });

--- a/test/address-search.test.ts
+++ b/test/address-search.test.ts
@@ -1,0 +1,37 @@
+import { describe } from '@jest/globals';
+import { AddressComponents, addressSearch, SearchAPI } from '../src/lib/address-search';
+
+describe('Test the address search component', () => {
+  const addressComponents: AddressComponents = {
+    placeId: 'abcd',
+    streetNumber: '32',
+    countryCode: 'AU',
+    country: 'Australia',
+    freeformAddress: '32 Charlotte Street, Melbourne, VIC, 7000',
+    municipality: 'Melbourne'
+  };
+  const searchApi: SearchAPI = (address): Promise<AddressComponents[]> => {
+    return new Promise(function (resolve, reject) {
+      resolve([addressComponents]);
+    });
+  };
+
+  it('returns a promise', () => {
+    const res = addressSearch(searchApi)('32 Charlotte St');
+    expect(res).toBeInstanceOf(Promise);
+  });
+
+  it('can fetch from the autocomplete api', async () => {
+    const res = await addressSearch(searchApi)('32 Charlotte St');
+    const firstRes = res[0];
+    expect(firstRes).toHaveProperty('suggestion');
+
+    const firstComponents = firstRes.components;
+    expect(firstComponents).toHaveProperty('placeId');
+    expect(firstComponents).toHaveProperty('streetNumber');
+    expect(firstComponents).toHaveProperty('countryCode');
+    expect(firstComponents).toHaveProperty('country');
+    expect(firstComponents).toHaveProperty('freeformAddress');
+    expect(firstComponents).toHaveProperty('municipality');
+  });
+});

--- a/test/auto-complete.test.ts
+++ b/test/auto-complete.test.ts
@@ -1,26 +1,34 @@
+// disabling tschecks to allow us to check the case of an unsupported
+// version being passed in the config since its defined as a union type
+//
+// @eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import { describe } from '@jest/globals';
-import { getAutoCompleteDetails } from '../src';
+import { AutoComplete, AutoCompleteConfig, AutoCompleteError } from '../src';
 
-// These are end-to-end tests and need an api key
-describe('Tomtom Places E2E Tests', () => {
-  describe('getAutoCompleteDetails', () => {
-    it('returns a promise', () => {
-      const res = getAutoCompleteDetails('Charlotte Street');
-      expect(res).toBeInstanceOf(Promise);
+// These are config loading tests
+describe('Test the library is able to be imported', () => {
+  describe('test the libray entry point', () => {
+    it('provides an AutoComplete function', () => {
+      expect(AutoComplete).toBeInstanceOf(Object);
     });
 
-    it('can fetch from the autocomplete api', async () => {
-      const res = await getAutoCompleteDetails('32 Charlotte Street');
-      const firstRes = res[0];
-      expect(firstRes).toHaveProperty('suggestion');
+    it('accepts a configuration object for suppling library version', () => {
+      const autoCompleteConfig: AutoCompleteConfig = {
+        version: 1
+      };
 
-      const firstComponents = firstRes.components;
-      expect(firstComponents).toHaveProperty('placeId');
-      expect(firstComponents).toHaveProperty('streetNumber');
-      expect(firstComponents).toHaveProperty('countryCode');
-      expect(firstComponents).toHaveProperty('country');
-      expect(firstComponents).toHaveProperty('freeformAddress');
-      expect(firstComponents).toHaveProperty('municipality');
+      const addressSearch = AutoComplete(autoCompleteConfig);
+      expect(addressSearch.search).toBeInstanceOf(Function);
+      expect(addressSearch.version()).toBe(1);
+    });
+
+    it('throws an error if an unsupported library version is provided', () => {
+      expect(() => {
+        AutoComplete({
+          version: 3
+        });
+      }).toThrow(AutoCompleteError.UNSUPPORTED_LIBRARY_VERSION);
     });
   });
 });

--- a/test/config-provider.test.ts
+++ b/test/config-provider.test.ts
@@ -10,6 +10,10 @@ describe('Test the correct configuration is correctly loaded', () => {
       const apiKey = Config.tomTomApiKey;
       expect(apiKey).toBeDefined();
       expect(apiKey).not.toBe('');
+
+      const allowedCountries = Config.tomTomCountriesAllowed;
+      expect(allowedCountries).toBeDefined();
+      expect(allowedCountries).toBe('AU,AUS');
     });
   });
 });

--- a/test/config-provider.test.ts
+++ b/test/config-provider.test.ts
@@ -2,7 +2,7 @@ import { describe } from '@jest/globals';
 import { Config } from '../src/providers/config';
 
 // These are config loading tests
-describe('Tomtom Places E2E Tests', () => {
+describe('Test the correct configuration is correctly loaded', () => {
   describe('getTomTomApiKey', () => {
     it('loads the tom tom API Key', () => {
       expect(Config).toHaveProperty('tomTomApiKey');

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -9,7 +9,6 @@ function getWithUndefined(): OptionalProperty {
   return {};
 }
 
-// These are config loading tests
 describe('Test helper function', () => {
   describe('valueOrDefault', () => {
     it('gives back the value when supplied', () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,0 +1,27 @@
+import { describe } from '@jest/globals';
+import { valueOrDefault } from '../src/helpers';
+
+type OptionalProperty = {
+  value?: string;
+};
+
+function getWithUndefined(): OptionalProperty {
+  return {};
+}
+
+// These are config loading tests
+describe('Test helper function', () => {
+  describe('valueOrDefault', () => {
+    it('gives back the value when supplied', () => {
+      expect(valueOrDefault('this is fine')).toBe('this is fine');
+    });
+
+    it('gives back an empty string when undefined and no default is provided', () => {
+      expect(valueOrDefault(getWithUndefined().value)).toBe('');
+    });
+
+    it('gives back an the default that was provided when undefined', () => {
+      expect(valueOrDefault(getWithUndefined().value, 'default')).toBe('default');
+    });
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,11 +1,18 @@
 import { describe } from '@jest/globals';
-import { getAutoCompleteDetails } from '../src';
+import { AutoComplete } from '../src';
 
 // These are config loading tests
 describe('Test the library is able to be imported', () => {
   describe('test the libray entry point', () => {
-    it('provides a function', () => {
-      expect(getAutoCompleteDetails).toBeInstanceOf(Function);
+    it('provides a function to create an AutoComplete object', () => {
+      expect(AutoComplete).toBeInstanceOf(Function);
+    });
+
+    it('provides a object to search for address suggestions', () => {
+      const autoComplete = AutoComplete({ version: 1 });
+      expect(autoComplete).toBeInstanceOf(Object);
+      expect(autoComplete).toHaveProperty('search');
+      expect(autoComplete).toHaveProperty('version');
     });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,11 @@
+import { describe } from '@jest/globals';
+import { getAutoCompleteDetails } from '../src';
+
+// These are config loading tests
+describe('Test the library is able to be imported', () => {
+  describe('test the libray entry point', () => {
+    it('provides a function', () => {
+      expect(getAutoCompleteDetails).toBeInstanceOf(Function);
+    });
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,6 @@
 import { describe } from '@jest/globals';
 import { AutoComplete } from '../src';
 
-// These are config loading tests
 describe('Test the library is able to be imported', () => {
   describe('test the libray entry point', () => {
     it('provides a function to create an AutoComplete object', () => {

--- a/test/maps-api.test.ts
+++ b/test/maps-api.test.ts
@@ -1,6 +1,16 @@
+// disabling tschecks to allow us to check the case of an unsupported
+// version being passed in the config since its defined as a union type
+//
+// @eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import { describe } from '@jest/globals';
 import { Config } from '../src/providers/config';
-import { getPlaceAutocomplete, TomTomAPIConfig } from '../src/third-party/maps-api';
+import {
+  getPlaceAutocomplete,
+  TomTomAPIConfig,
+  TomTomAPIResponse,
+  validResult
+} from '../src/third-party/maps-api';
 
 // These are end-to-end tests and need an api key
 describe('Tomtom Places E2E Tests', () => {
@@ -20,6 +30,50 @@ describe('Tomtom Places E2E Tests', () => {
 
     it('handles error', async () => {
       expect(getAutoCompleteDetails('')).rejects.toThrow();
+    });
+  });
+
+  describe('validResult', () => {
+    const idWithNoAddress: TomTomAPIResult = {
+      id: 'abc'
+    };
+
+    const addressWithNoId: TomTomAPIResult = {
+      address: {
+        streetName: 'Charlotte St',
+        municipality: 'Melbourne',
+        postalCode: '3000',
+        countryCode: 'AU',
+        country: 'Australia',
+        freeformAddress: '32 Charlotte St, Melbourne Australia 3000'
+      }
+    };
+
+    const completeWithIdAndAddress: TomTomAPIResult = {
+      ...idWithNoAddress,
+      ...addressWithNoId
+    };
+
+    it('result without an address is invalid', async () => {
+      expect(validResult(idWithNoAddress)).toBeFalsy();
+    });
+
+    it('result without an id is invalid', async () => {
+      expect(validResult(addressWithNoId)).toBeFalsy();
+    });
+
+    it('handles a valid result', async () => {
+      expect(validResult(completeWithIdAndAddress)).toBeTruthy();
+    });
+
+    it('result with a missing required address field', async () => {
+      const missingARequiredAddressField: TomTomAPIResult = {
+        ...idWithNoAddress,
+        ...addressWithNoId
+      };
+
+      delete missingARequiredAddressField.address.freeformAddress;
+      expect(validResult(missingARequiredAddressField)).toBeFalsy();
     });
   });
 });

--- a/test/maps-api.test.ts
+++ b/test/maps-api.test.ts
@@ -1,5 +1,5 @@
-// disabling tschecks to allow us to check the case of an unsupported
-// version being passed in the config since its defined as a union type
+// disabling tschecks to enable us to test broken data structures that may
+// be returned from the tom tom api
 //
 // @eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
@@ -7,20 +7,152 @@ import { describe } from '@jest/globals';
 import { Config } from '../src/providers/config';
 import {
   getPlaceAutocomplete,
+  mapsApi,
   TomTomAPIConfig,
   TomTomAPIResponse,
-  validResult
+  TomTomAPIResult,
+  TomTomMapsAPI
 } from '../src/third-party/maps-api';
+import { PartialAddress } from '../src/lib/address-search';
 
 // These are end-to-end tests and need an api key
-describe('Tomtom Places E2E Tests', () => {
+describe('Tomtom Places unit tests', () => {
   const tomTomConfig: TomTomAPIConfig = {
     key: Config.tomTomApiKey,
     version: 2,
     countrySet: Config.tomTomCountriesAllowed
   };
 
-  const getAutoCompleteDetails = getPlaceAutocomplete(tomTomConfig);
+  const mockMapsApi =
+    (response: TomTomAPIResponse): TomTomMapsAPI =>
+    (config: TomTomAPIConfig, address: PartialAddress): Promise<TomTomAPIResponse> => {
+      return new Promise(function (resolve, reject) {
+        if (response.status === 200) {
+          resolve(response);
+        } else {
+          throw Error('apiError');
+        }
+      });
+    };
+
+  describe('getPlaceAutocomplete', () => {
+    it('handles no results', async () => {
+      const mockApi = mockMapsApi({
+        data: { results: [] },
+        status: 200,
+        statusText: 'OK',
+        headers: [],
+        config: {}
+      });
+      const getAutoCompleteDetails = getPlaceAutocomplete(tomTomConfig, mockApi);
+      const res = await getAutoCompleteDetails('asfasffasfasafsafs');
+
+      expect(res).toStrictEqual([]);
+    });
+
+    it('handles error', async () => {
+      const mockApi = mockMapsApi({
+        data: { results: [] },
+        status: 500,
+        statusText: 'OK',
+        headers: [],
+        config: {}
+      });
+      const getAutoCompleteDetails = getPlaceAutocomplete(tomTomConfig, mockApi);
+      expect(getAutoCompleteDetails('')).rejects.toThrow();
+    });
+  });
+
+  describe('validResult', () => {
+    it('result without an address is invalid', async () => {
+      const result = getValidResult();
+      delete result.id;
+      const mockApi = mockMapsApi({
+        data: { results: [result] },
+        status: 200,
+        statusText: 'OK',
+        headers: [],
+        config: {}
+      });
+      const getAutoCompleteDetails = getPlaceAutocomplete(tomTomConfig, mockApi);
+      const res = await getAutoCompleteDetails('32 Charlotte St');
+
+      expect(res.length).toBe(0);
+    });
+
+    it('result without an id is invalid', async () => {
+      const result = getValidResult();
+      delete result.address;
+
+      const mockApi = mockMapsApi({
+        data: { results: [result] },
+        status: 200,
+        statusText: 'OK',
+        headers: [],
+        config: {}
+      });
+      const getAutoCompleteDetails = getPlaceAutocomplete(tomTomConfig, mockApi);
+      const res = await getAutoCompleteDetails('32 Charlotte St');
+
+      expect(res.length).toBe(0);
+    });
+
+    it('handles a valid result', async () => {
+      const result = getValidResult();
+
+      const mockApi = mockMapsApi({
+        data: { results: [result] },
+        status: 200,
+        statusText: 'OK',
+        headers: [],
+        config: {}
+      });
+      const getAutoCompleteDetails = getPlaceAutocomplete(tomTomConfig, mockApi);
+      const res = await getAutoCompleteDetails('32 Charlotte St');
+
+      expect(res.length).toBe(1);
+    });
+
+    it('result with a missing required address field', async () => {
+      const result = getValidResult();
+      delete result.address.freeformAddress;
+
+      const mockApi = mockMapsApi({
+        data: { results: [result] },
+        status: 200,
+        statusText: 'OK',
+        headers: [],
+        config: {}
+      });
+      const getAutoCompleteDetails = getPlaceAutocomplete(tomTomConfig, mockApi);
+      const res = await getAutoCompleteDetails('32 Charlotte St');
+
+      expect(res.length).toBe(0);
+    });
+  });
+});
+
+function getValidResult(): TomTomAPIResult {
+  return {
+    id: 'abc',
+    address: {
+      streetName: 'Charlotte St',
+      municipality: 'Melbourne',
+      postalCode: '3000',
+      countryCode: 'AU',
+      country: 'Australia',
+      freeformAddress: '32 Charlotte St, Melbourne Australia 3000'
+    }
+  };
+}
+
+describe('Tomtom Places E2E Tests', () => {
+  const tomTomConfig: TomTomAPIConfig = {
+    key: Config.tomTomApiKey,
+    version: 2,
+    countrySet: Config.tomTomCountriesAllowed
+  };
+  const getAutoCompleteDetails = getPlaceAutocomplete(tomTomConfig, mapsApi);
 
   describe('getPlaceAutocomplete', () => {
     it('handles no results', async () => {
@@ -30,50 +162,6 @@ describe('Tomtom Places E2E Tests', () => {
 
     it('handles error', async () => {
       expect(getAutoCompleteDetails('')).rejects.toThrow();
-    });
-  });
-
-  describe('validResult', () => {
-    const idWithNoAddress: TomTomAPIResult = {
-      id: 'abc'
-    };
-
-    const addressWithNoId: TomTomAPIResult = {
-      address: {
-        streetName: 'Charlotte St',
-        municipality: 'Melbourne',
-        postalCode: '3000',
-        countryCode: 'AU',
-        country: 'Australia',
-        freeformAddress: '32 Charlotte St, Melbourne Australia 3000'
-      }
-    };
-
-    const completeWithIdAndAddress: TomTomAPIResult = {
-      ...idWithNoAddress,
-      ...addressWithNoId
-    };
-
-    it('result without an address is invalid', async () => {
-      expect(validResult(idWithNoAddress)).toBeFalsy();
-    });
-
-    it('result without an id is invalid', async () => {
-      expect(validResult(addressWithNoId)).toBeFalsy();
-    });
-
-    it('handles a valid result', async () => {
-      expect(validResult(completeWithIdAndAddress)).toBeTruthy();
-    });
-
-    it('result with a missing required address field', async () => {
-      const missingARequiredAddressField: TomTomAPIResult = {
-        ...idWithNoAddress,
-        ...addressWithNoId
-      };
-
-      delete missingARequiredAddressField.address.freeformAddress;
-      expect(validResult(missingARequiredAddressField)).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
Add extra tests

Added
- tom tom api unit tests
- testing parameter mappings from tom tom api to address suggestion structure are correct
- testing the helper function for dealing with missing api keys (realistically no longer needed as non conforming api results are filtered out)
- testing validation for the response structure of the tom tom api

TODO:
- there could be improvements on the error pathways and error output